### PR TITLE
refactor(config): update firebase paths to use the new, versioned endpoints

### DIFF
--- a/app/scripts/app.js
+++ b/app/scripts/app.js
@@ -10,9 +10,9 @@ const C1V0 = C1V0 || {
    */
   config: {
     analytics: 'UA-33558417-1',
-    projects: 'https://chrisvogt.firebaseio.com/projects.json',
+    projects: 'https://chrisvogt.firebaseio.com/v1/projects.json',
     quotes: 'https://cdn.rawgit.com/chrisvogt/49b51791348a09cbddb0/raw/585d1712885dda5c13d63c17b5e093d543640e42/book-quotes.json',
-    social: 'https://chrisvogt.firebaseio.com/profiles.json',
+    social: 'https://chrisvogt.firebaseio.com/v1/profiles.json',
     hours: 'https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20json%20where%20url%3D%22https%3A%2F%2Fstats.chrisvogt.me%2Freports%2Fdashboard.json%22&diagnostics=true'
   },
 


### PR DESCRIPTION
I plan on [chrisvogt/personal-api](https://github.com/chrisvogt/personal-api) eventually replacing the firebase data. To prepare for the new schema, this PR versions the existing routes by moving the endpoints under a _/v1_ directory.

### Updated routes

These routes will remain active under all projects have successfully moved to `v2`.

https://chrisvogt.firebaseio.com/v1/projects.json
https://chrisvogt.firebaseio.com/v1/profiles.json