### PR TITLE
feat: add a recently-read books widget

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -102,6 +102,11 @@
                 Photos
               </a>
             </li>
+            <li data-magellan-arrival="recently-read">
+              <a href="#recently-read" title="Recently read books">
+                Recently Read
+              </a>
+            </li>
           </ul>
         </section>
       </nav>
@@ -190,6 +195,30 @@
               <i class="fa fa-refresh"></i> Load More
             </button>
           </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Component: Recently Read -->
+    <div id="recently-read" data-magellan-destination="recently-read">
+      <div class="row">
+        <div class="large-12 columns">
+            <div class="panel panel-controls small-only-text-center">
+              <p>
+                Recently read books. <span class="accent">Click on a thumbnail to view on Google Books.</span>
+
+                <a href="https://www.goodreads.com/user/show/10454947-chris-vogt" class="button secondary tiny" title="Chris Vogt on Goodreads"><i class="fa fa-book"></i> Visit Goodreads</a>
+              </p>
+            </div>
+          <ul id="recent-books" class="small-block-grid-3 medium-block-grid-6">
+            <template id="recent-book-template">
+              <li>
+                <a class="recent-book-link hvr-shadow-radial" href="" title="">
+                  <img class="recent-book-image" height="150" src="" alt="" />
+                </a>
+              </li>
+            </template>
+          </ul>
         </div>
       </div>
     </div>
@@ -342,6 +371,7 @@
     <script src="scripts/social-profiles.js"></script>
     <script src="scripts/analytics.jquery.js"></script>
     <script src="scripts/quotes.jquery.js"></script>
+    <script src="scripts/recently-read.js"></script>
     <!-- endbuild -->
   </body>
 </html>

--- a/app/scripts/recently-read.js
+++ b/app/scripts/recently-read.js
@@ -1,0 +1,30 @@
+(async () => {
+  const dom = {
+    select: document.querySelector.bind(document)
+  };
+
+  const template = dom.select('#recent-book-template').content;
+  const container = dom.select('#recent-books');
+
+  try {
+    const books = await $.getJSON({ url: 'https://recently-read.chrisvogt.me' });
+
+    for (const book of books.slice(0, 9)) {
+      const content = template.cloneNode(true);
+
+      const link = content.querySelector('.recent-book-link');
+      link.title = `${book.title} on Google Books`;
+      link.href = book.infoLink;
+
+      const image = content.querySelector('.recent-book-image');
+      image.src = book.smallThumbnail;
+      image.alt = book.title;
+
+      container.appendChild(document.importNode(content, true));
+    }
+  } catch (error) {
+    console.warn('Error loading recently read section', error);
+    dom.select('#recent-books').classList.add('hidden');
+    dom.select('#primary-nav li[data-magellan-arrival="recently-read"]').classList.add('hidden');
+  }
+})();

--- a/app/styles/_appstyles.scss
+++ b/app/styles/_appstyles.scss
@@ -10,7 +10,9 @@
 @import 'base/typography';
 
 /* Components */
+@import 'components/books';
 @import 'components/button';
+@import 'components/panel-controls';
 @import 'components/photos';
 @import 'components/projects';
 @import 'components/promo';

--- a/app/styles/components/_books.scss
+++ b/app/styles/components/_books.scss
@@ -1,0 +1,7 @@
+// -----------------------------------------------------------------------------
+// This file contains all styles related to the RECENTLY READ component.
+// -----------------------------------------------------------------------------
+
+#recent-books img {
+    max-height: 150px;
+}

--- a/app/styles/components/_panel-controls.scss
+++ b/app/styles/components/_panel-controls.scss
@@ -1,0 +1,45 @@
+.panel-controls {
+    background-color: white;
+    box-shadow: none;
+    margin: 24px auto;
+    padding: 32px 22px;
+
+    p {
+        margin-bottom: 0;
+    }
+
+    a {
+        margin-bottom: 0;
+    }
+
+    span.accent,
+    .button.secondary {
+        margin-bottom: 0;
+        margin-top: -4px;
+    }
+
+    span.accent {
+        color: $text-asher;
+        display: block;
+        font-size: .75em;
+        margin-bottom: 8px;
+
+        @media only screen and (min-width: 40.063em) {
+            display: inline-block;
+            margin-bottom: 0;
+        }
+    }
+
+    .button.secondary {
+        color: white;
+        background-color: $vegas-gold;
+
+        &:hover {
+            background-color: lighten($vegas-gold, 15%);
+        }
+
+        @media only screen and (min-width: 40.063em) {
+            float: right;
+        }
+    }
+}

--- a/app/styles/components/_photos.scss
+++ b/app/styles/components/_photos.scss
@@ -3,52 +3,6 @@
 // -----------------------------------------------------------------------------
 
 #photos {
-    .panel-controls {
-        background-color: white;
-        box-shadow: none;
-        margin: 24px auto;
-        padding: 32px 22px;
-
-        p {
-            margin-bottom: 0;
-        }
-
-        a {
-            margin-bottom: 0;
-        }
-
-        span.accent,
-        .button.secondary {
-            margin-bottom: 0;
-            margin-top: -4px;
-        }
-
-        span.accent {
-            color: $text-asher;
-            display: block;
-            font-size: .75em;
-            margin-bottom: 8px;
-
-            @media only screen and (min-width: 40.063em) {
-                display: inline-block;
-                margin-bottom: 0;
-            }
-        }
-
-        .button.secondary {
-            color: white;
-            background-color: $vegas-gold;
-
-            &:hover {
-                background-color: lighten($vegas-gold, 15%);
-            }
-
-            @media only screen and (min-width: 40.063em) {
-                float: right;
-            }
-        }
-    }
-
     ul {
         margin: 0 -0.625rem -1.25em;
     }


### PR DESCRIPTION
This PR adds a new recently-read books widget to the page. The book data is served from http://recently-read.chrisvogt.me, which is running [chrisvogt/recently-read](https://github.com/chrisvogt/recently-read).

### Screenshots

###### Chrome on macOS Mojave

<img width="1122" alt="screen shot 2018-11-17 at 12 42 32 pm" src="https://user-images.githubusercontent.com/1934719/48665604-7842af00-ea66-11e8-8753-1f7b6e0af54f.png">

###### Safari on iPhone XS

<img width="340" alt="screen shot 2018-11-17 at 12 41 58 pm" src="https://user-images.githubusercontent.com/1934719/48665607-885a8e80-ea66-11e8-86cf-bd2fd2058221.png">
