### PR TITLE
feat: update home page section styles to look like cards

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -148,7 +148,7 @@
     </section>
 
     <!-- Component: Projects -->
-    <section id="projects" data-magellan-destination="projects">
+    <section id="projects" class="mb-3" data-magellan-destination="projects">
       <div class="row">
         <div class="small-12 medium-3 columns">
           <h3>Latest Commit</h3>
@@ -193,7 +193,7 @@
     <!-- Component: Instafeed -->
     <div id="photos" class="hidden" data-magellan-destination="photos">
       <div class="row">
-        <div class="large-12 columns">
+        <div class="panel panel-card large-12 columns">
           <div class="panel panel-controls small-only-text-center">
             <p>
               Recent Photos. <span class="accent">Click on a thumbnail to view in Instagram.</span>
@@ -218,7 +218,7 @@
     <!-- Component: Recently Read -->
     <div id="recently-read" data-magellan-destination="recently-read">
       <div class="row">
-        <div class="large-12 columns">
+        <div class="panel panel-card large-12 columns">
             <div class="panel panel-controls small-only-text-center">
               <p>
                 Recently read books. <span class="accent">Click on a thumbnail to view on Google Books.</span>

--- a/app/index.html
+++ b/app/index.html
@@ -148,7 +148,7 @@
     </section>
 
     <!-- Component: Projects -->
-    <section id="projects" class="mb-3" data-magellan-destination="projects">
+    <section id="projects" data-magellan-destination="projects">
       <div class="row">
         <div class="small-12 medium-3 columns">
           <h3>Latest Commit</h3>
@@ -190,51 +190,53 @@
       </div>
     </section>
 
-    <!-- Component: Instafeed -->
-    <div id="photos" class="hidden" data-magellan-destination="photos">
-      <div class="row">
-        <div class="panel panel-card large-12 columns">
-          <div class="panel panel-controls small-only-text-center">
-            <p>
-              Recent Photos. <span class="accent">Click on a thumbnail to view in Instagram.</span>
+    <div class="pt-3 bg-dark-grey">
+      <!-- Component: Instafeed -->
+      <div id="photos" class="hidden" data-magellan-destination="photos">
+        <div class="row">
+          <div class="panel large-12 columns">
+            <div class="panel panel-controls small-only-text-center">
+              <p>
+                Recent Photos. <span class="accent">Click on a thumbnail to view in Instagram.</span>
 
-              <a href="https://www.instagram.com/c1v0/" class="button secondary tiny" title="C1V0 on Instagram"><i class="fa fa-instagram"></i> Visit Instagram</a>
-            </p>
-          </div>
+                <a href="https://www.instagram.com/c1v0/" class="button secondary tiny" title="C1V0 on Instagram"><i class="fa fa-instagram"></i> Visit Instagram</a>
+              </p>
+            </div>
 
-          <ul id="instafeed" class="small-block-grid-3 medium-block-grid-6">
-            <!-- AJAX: instagram photos -->
-          </ul>
+            <ul id="instafeed" class="small-block-grid-3 medium-block-grid-6">
+              <!-- AJAX: instagram photos -->
+            </ul>
 
-          <div class="panel panel-sub text-center">
-            <button type="button" class="js-load-more button tiny dodger-blue" title="Load More">
-              <i class="fa fa-refresh"></i> Load More
-            </button>
+            <div class="panel panel-sub text-center">
+              <button type="button" class="js-load-more button tiny dodger-blue" title="Load More">
+                <i class="fa fa-refresh"></i> Load More
+              </button>
+            </div>
           </div>
         </div>
       </div>
-    </div>
 
-    <!-- Component: Recently Read -->
-    <div id="recently-read" data-magellan-destination="recently-read">
-      <div class="row">
-        <div class="panel panel-card large-12 columns">
-            <div class="panel panel-controls small-only-text-center">
-              <p>
-                Recently read books. <span class="accent">Click on a thumbnail to view on Google Books.</span>
+      <!-- Component: Recently Read -->
+      <div id="recently-read" data-magellan-destination="recently-read">
+        <div class="row">
+          <div class="panel large-12 columns">
+              <div class="panel panel-controls small-only-text-center">
+                <p>
+                  Recently read books. <span class="accent">Click on a thumbnail to view on Google Books.</span>
 
-                <a href="https://www.goodreads.com/user/show/10454947-chris-vogt" class="button secondary tiny" title="Chris Vogt on Goodreads"><i class="fa fa-book"></i> Visit Goodreads</a>
-              </p>
-            </div>
-          <ul id="recent-books" class="small-block-grid-3 medium-block-grid-6">
-            <template id="recent-book-template">
-              <li>
-                <a class="recent-book-link hvr-shadow-radial" href="" title="">
-                  <img class="recent-book-image" height="150" src="" alt="" />
-                </a>
-              </li>
-            </template>
-          </ul>
+                  <a href="https://www.goodreads.com/user/show/10454947-chris-vogt" class="button secondary tiny" title="Chris Vogt on Goodreads"><i class="fa fa-book"></i> Visit Goodreads</a>
+                </p>
+              </div>
+            <ul id="recent-books" class="small-block-grid-3 medium-block-grid-6">
+              <template id="recent-book-template">
+                <li>
+                  <a class="recent-book-link hvr-shadow-radial" href="" title="">
+                    <img class="recent-book-image" height="150" src="" alt="" />
+                  </a>
+                </li>
+              </template>
+            </ul>
+          </div>
         </div>
       </div>
     </div>

--- a/app/styles/abstracts/_variables.scss
+++ b/app/styles/abstracts/_variables.scss
@@ -8,6 +8,7 @@ $base-grey: #fefefe;
 $grey-50: #fafafa;
 $grey-100: #f5f5f5;
 $grey-200: #eee;
+$grey-800: #424242;
 $grey-900: #212121;
 $blue-grey-50: #eceff1;
 

--- a/app/styles/abstracts/_variables.scss
+++ b/app/styles/abstracts/_variables.scss
@@ -44,3 +44,4 @@ $text-default-font-stack: 'Merriweather', serif;
 $divider-light: 1px solid #dfdfdf;
 $default-border-radius: 4px;
 $default-box-shadow: 0 0 4px rgba(0,0,0,.14), 0 4px 8px rgba(0,0,0,.28);
+$default-spacing: 1.25em;

--- a/app/styles/base/_helpers.scss
+++ b/app/styles/base/_helpers.scss
@@ -49,3 +49,10 @@ img.circle {
 .align-self-center {
     align-self: center;
 }
+
+/**
+ * Spacing helpers
+ */
+.mb-3 {
+    margin-bottom: 1.25em;
+}

--- a/app/styles/base/_helpers.scss
+++ b/app/styles/base/_helpers.scss
@@ -50,9 +50,19 @@ img.circle {
     align-self: center;
 }
 
+$default-spacing: 1.25em;
+
 /**
  * Spacing helpers
  */
 .mb-3 {
-    margin-bottom: 1.25em;
+    margin-bottom: $default-spacing;
+}
+
+.pt-3 {
+    padding-top: $default-spacing;
+}
+
+.bg-dark-grey {
+    background-color: $grey-800;
 }

--- a/app/styles/base/_helpers.scss
+++ b/app/styles/base/_helpers.scss
@@ -50,8 +50,6 @@ img.circle {
     align-self: center;
 }
 
-$default-spacing: 1.25em;
-
 /**
  * Spacing helpers
  */

--- a/app/styles/components/_quotes.scss
+++ b/app/styles/components/_quotes.scss
@@ -7,7 +7,6 @@ section#quote {
     text-align: center;
     min-height: 200px;
     padding: 50px;
-    margin: 24px 0 0;
 
     p {
         line-height: 50px;

--- a/app/styles/layout/_common.scss
+++ b/app/styles/layout/_common.scss
@@ -3,7 +3,7 @@
 // -----------------------------------------------------------------------------
 
 body {
-    background: $grey-800;
+    background: $blue-grey-50;
 }
 
 .contain-to-grid,

--- a/app/styles/layout/_common.scss
+++ b/app/styles/layout/_common.scss
@@ -3,7 +3,7 @@
 // -----------------------------------------------------------------------------
 
 body {
-    background: $blue-grey-50;
+    background: $grey-800;
 }
 
 .contain-to-grid,


### PR DESCRIPTION
This PR polishes the home page styling by updating the background to be a dark grey and styling the content sections to render as cards.

### Screenshots

![download](https://user-images.githubusercontent.com/1934719/49355721-9ff86080-f67d-11e8-8844-9b28a8f77184.jpg)
