### PR TITLE
 feat: hide recent books section until loaded

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -102,7 +102,7 @@
                 Photos
               </a>
             </li>
-            <li data-magellan-arrival="recently-read">
+            <li class="hidden" data-magellan-arrival="recently-read">
               <a href="#recently-read" title="Recently read books">
                 Recently Read
               </a>
@@ -217,7 +217,7 @@
       </div>
 
       <!-- Component: Recently Read -->
-      <div id="recently-read" data-magellan-destination="recently-read">
+      <div id="recently-read" class="hidden" data-magellan-destination="recently-read">
         <div class="row">
           <div class="panel large-12 columns">
               <div class="panel panel-controls small-only-text-center">

--- a/app/scripts/recently-read.js
+++ b/app/scripts/recently-read.js
@@ -26,6 +26,5 @@
     }
   } catch (error) {
     console.warn('Error loading recently read section', error);
-    navButton.classList.add('hidden');
   }
 })();

--- a/app/scripts/recently-read.js
+++ b/app/scripts/recently-read.js
@@ -3,12 +3,13 @@
     select: document.querySelector.bind(document)
   };
 
+  const container = dom.select('#recently-read');
+  const bookList = dom.select('#recent-books');
+  const navButton = dom.select('#primary-nav li[data-magellan-arrival="recently-read"]');
   const template = dom.select('#recent-book-template').content;
-  const container = dom.select('#recent-books');
 
   try {
     const books = await $.getJSON({url: 'https://recently-read.chrisvogt.me'});
-
     for (const book of books.slice(0, 9)) {
       const content = template.cloneNode(true);
 
@@ -20,11 +21,11 @@
       image.src = book.smallThumbnail;
       image.alt = book.title;
 
-      container.appendChild(document.importNode(content, true));
+      bookList.appendChild(document.importNode(content, true));
+      [container, navButton].forEach(el => el.classList.remove('hidden'));
     }
   } catch (error) {
     console.warn('Error loading recently read section', error);
-    dom.select('#recent-books').classList.add('hidden');
-    dom.select('#primary-nav li[data-magellan-arrival="recently-read"]').classList.add('hidden');
+    navButton.classList.add('hidden');
   }
 })();


### PR DESCRIPTION
This PR updates the recently-read books section to be hidden by default. This is a quick solution to a defect visible on the live site when the microservice responds slowly or has gone to sleep.

### Screenshot

![recording-recently-read](https://user-images.githubusercontent.com/1934719/49570034-6b3d1100-f8ea-11e8-9275-f50a2fa98b73.gif)
