### PR TITLE
fix: build vendor JS before running local server

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "www.chrisvogt.me",
-  "version": "0.8.6",
+  "version": "0.9.0-beta",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,9 +22,10 @@
     "js:min": "uglifyjs ./assets/js/app.js -o ./assets/js/app.js",
     "js:vendors": "uglifyjs $(cat ./vendor-packages.txt) -o ./assets/js/vendor.min.js",
     "build": "npm run js:vendors && npm run js:babel && npm run js:min && jekyll build --config _config.prod.yml",
-    "lint": "xo _includes/js",
+    "prestart": "npm run js:clean && npm run js:vendors && npm run js",
+    "start": "bundle exec jekyll serve --watch --incremental --drafts",
     "pretest": "npm run build",
-    "start": "bundle exec jekyll serve --watch --incremental --drafts & npm run js",
+    "lint": "xo _includes/js",
     "test": "bundlesize"
   },
   "devDependencies": {


### PR DESCRIPTION
When running from a fresh install I noticed that the vendor scripts aren't building before the local server runs. This PR updates the npm scripts so that all JS is built before the local server starts.