### PR TITLE
refactor: modules to pass in the dom selector and jQuery

### DIFF
--- a/_includes/js/latest-commit.js
+++ b/_includes/js/latest-commit.js
@@ -4,10 +4,8 @@ const getRelativeTimeSinceString = date => {
   return timeago ? timeago(date) : new Date(date).toISOString();
 };
 
-export default async jQuery => {
+export default async ({dom, jQuery}) => {
   const {getJSON} = jQuery;
-  const dom = {select: document.querySelector.bind(document)};
-
   const username = 'chrisvogt';
   const response = await getJSON({url: `https://api.github.com/users/${username}/events/public`});
 

--- a/_includes/js/latest-repos.js
+++ b/_includes/js/latest-repos.js
@@ -1,8 +1,4 @@
-export default async () => {
-  const dom = {
-    select: document.querySelector.bind(document)
-  };
-
+export default async ({dom, jQuery}) => {
   const container = dom.select('#latest-repos-items');
   const placeholderTemplate = dom.select('#latest-repo-placeholder').content;
   const template = dom.select('#latest-repos-template').content;
@@ -13,7 +9,8 @@ export default async () => {
   }
 
   try {
-    const response = await $.getJSON({url: 'https://gh-latest-repos-fmyaneprcd.now.sh'});
+    const {getJSON} = jQuery;
+    const response = await getJSON({url: 'https://gh-latest-repos-fmyaneprcd.now.sh'});
     const repos = response.reverse().filter(repo => Boolean(repo.description));
 
     container.innerHTML = '';

--- a/_includes/js/load-layout-modules.js
+++ b/_includes/js/load-layout-modules.js
@@ -7,6 +7,14 @@ import recentlyRead from './recently-read';
 import socialProfiles from './social-profiles';
 import twitter from './twitter';
 
+const dom = {
+  select: document.querySelector.bind(document)
+};
+
+const commonModules = [
+  'social-profiles'
+];
+
 const registry = {
   instagram,
   'latest-commit': latestCommit,
@@ -18,19 +26,17 @@ const registry = {
   twitter
 };
 
-const commonModules = [
-  'social-profiles'
-];
-
 export default () => {
   const modules = [
     ...commonModules,
     ...(window.__WWW_LAYOUT_MODULES__ ? window.__WWW_LAYOUT_MODULES__ : [])
   ];
 
+  const props = {dom, jQuery};
+
   modules.forEach(moduleName => {
     try {
-      return registry[moduleName] && registry[moduleName](jQuery);
+      return registry[moduleName] && registry[moduleName](props);
     } catch (error) {
       console.warn(`Error loading the ${moduleName} module.`, error);
     }

--- a/_includes/js/load-layout-modules.js
+++ b/_includes/js/load-layout-modules.js
@@ -32,11 +32,11 @@ export default () => {
     ...(window.__WWW_LAYOUT_MODULES__ ? window.__WWW_LAYOUT_MODULES__ : [])
   ];
 
-  const props = {dom, jQuery};
+  const args = {dom, jQuery};
 
   modules.forEach(moduleName => {
     try {
-      return registry[moduleName] && registry[moduleName](props);
+      return registry[moduleName] && registry[moduleName](args);
     } catch (error) {
       console.warn(`Error loading the ${moduleName} module.`, error);
     }

--- a/_includes/js/quotes.js
+++ b/_includes/js/quotes.js
@@ -1,13 +1,10 @@
-export default async () => {
-  const dom = {
-    select: document.querySelector.bind(document)
-  };
-
+export default async ({dom, jQuery}) => {
   const template = dom.select('#quote-template').content;
   const container = dom.select('#quote-container');
 
   try {
-    const {result: {quotes}} = await $.getJSON({url: 'https://api.chrisvogt.me/quotes'});
+    const {getJSON} = jQuery;
+    const {result: {quotes}} = await getJSON({url: 'https://api.chrisvogt.me/quotes'});
     const fragment = document.createDocumentFragment();
 
     if (!quotes || quotes.length === 0) {

--- a/_includes/js/recently-read.js
+++ b/_includes/js/recently-read.js
@@ -1,15 +1,12 @@
-export default async () => {
-  const dom = {
-    select: document.querySelector.bind(document)
-  };
-
+export default async ({dom, jQuery}) => {
   const container = dom.select('#recently-read');
   const bookList = dom.select('#recent-books');
   const navButton = dom.select('#primary-nav li[data-magellan-arrival="recently-read"]');
   const template = dom.select('#recent-book-template').content;
 
   try {
-    const books = await $.getJSON({url: 'https://recently-read.chrisvogt.me'});
+    const {getJSON} = jQuery;
+    const books = await getJSON({url: 'https://recently-read.chrisvogt.me'});
     for (const book of books.slice(0, 9)) {
       const content = template.cloneNode(true);
 

--- a/_includes/js/social-profiles.js
+++ b/_includes/js/social-profiles.js
@@ -1,13 +1,10 @@
-export default async () => {
-  const dom = {
-    select: document.querySelector.bind(document)
-  };
-
+export default async ({dom, jQuery}) => {
   const template = dom.select('#social-item-template').content;
   const container = dom.select('#social-profiles');
 
   try {
-    const profiles = await $.getJSON({url: 'https://chrisvogt.firebaseio.com/v1/profiles.json'});
+    const {getJSON} = jQuery;
+    const profiles = await getJSON({url: 'https://chrisvogt.firebaseio.com/v1/profiles.json'});
 
     if (!profiles || profiles.length === 0) {
       throw new Error('No profiles found.');


### PR DESCRIPTION
This PR refactors the JavaScript modules to pass in the dom selector and jQuery as params instead of redefining (`dom`) or assuming it's available in the global namespace (`$`).