### PR TITLE
refactor: remove scrollup and unused deps

### DIFF
--- a/_includes/js/navigation.js
+++ b/_includes/js/navigation.js
@@ -48,8 +48,6 @@ export default () => {
     });
   };
 
-  $.scrollUp();
-
   fadableHeader();
   initMagellan();
 };

--- a/assets/styles/layout/_accents.scss
+++ b/assets/styles/layout/_accents.scss
@@ -29,33 +29,6 @@ em.accent {
     color: #90A4AE;
 }
 
-#scrollUp {
-    bottom: 20px;
-    right: 20px;
-    background-color: $vegas-gold;
-    box-shadow: $default-box-shadow;
-    color: #5D436F;
-    font-size: 12px;
-    font-family: sans-serif;
-    text-decoration: none;
-    opacity: .9;
-    padding: 10px 20px;
-    -webkit-transition: background 200ms linear;
-    -moz-transition: background 200ms linear;
-    -o-transition: background 200ms linear;
-    transition: background 200ms linear;
-    -webkit-backface-visibility: hidden;
-
-    &:hover {
-        background-color: lighten($vegas-gold, 10%);
-    }
-
-    @media only screen and (max-width: 64.063em) {
-        display: none !important;
-        border: 1px solid red;
-    }
-}
-
 #project-list li,
 #social a,
 .button {

--- a/bower.json
+++ b/bower.json
@@ -2,16 +2,10 @@
   "name": "www",
   "description": "Personal website and project portfolio",
   "dependencies": {
-    "SVG-Loaders": "svg-loaders#^1.0.2",
     "foundation": "https://github.com/chrisvogt/bower-foundation.git#master",
-    "scrollup": "~2.4.1",
     "jquery": "~2.2.4",
     "instafeed.js": "^1.4.1",
     "jquery-timeago": "^1.6.3"
-  },
-  "devDependencies": {
-    "chai": "^3.5.0",
-    "mocha": "^3.2.0"
   },
   "private": true,
   "resolutions": {

--- a/humans.txt
+++ b/humans.txt
@@ -6,7 +6,7 @@ Location: San Francisco, California, USA
 
 /* SITE */
 Standards: HTML5, CSS3, JSON, SVG
-Components: Modernizr, jQuery, ZURB Foundation, Moment.js, scrollUp, Fastclick
+Components: Modernizr, jQuery, ZURB Foundation, Moment.js, Fastclick
 Software: Node.js, Gulp, EditorConfig, TravisCI, Git, Bower, NPM
 
 Pure logical thinking cannot yield us any knowledge of the empirical world; all knowledge of reality starts from experience and ends in it. —Albert Einstein, "Ideas and Opinions"

--- a/vendor-packages.txt
+++ b/vendor-packages.txt
@@ -10,5 +10,4 @@
 ./bower_components/foundation/js/foundation/foundation.orbit.js
 ./bower_components/foundation/js/foundation/foundation.tooltip.js
 ./bower_components/foundation/js/foundation/foundation.topbar.js
-./bower_components/scrollup/dist/jquery.scrollUp.min.js
 ./bower_components/instafeed.js/instafeed.js


### PR DESCRIPTION
This small refactor removes the Scrollup widget and remaining unused dependencies.