### PR TITLE
refactor: move (nearly) all JS dependencies to npm from Bower

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   - v8
 before_install:
-  - npm install -g bower gulp
+  - npm install -g bower
   - bower install
   - gem install bundler
   - bundle install

--- a/bower.json
+++ b/bower.json
@@ -3,9 +3,7 @@
   "description": "Personal website and project portfolio",
   "dependencies": {
     "foundation": "https://github.com/chrisvogt/bower-foundation.git#master",
-    "jquery": "~2.2.4",
-    "instafeed.js": "^1.4.1",
-    "jquery-timeago": "^1.6.3"
+    "jquery": "~2.2.4"
   },
   "private": true,
   "resolutions": {

--- a/humans.txt
+++ b/humans.txt
@@ -6,7 +6,7 @@ Location: San Francisco, California, USA
 
 /* SITE */
 Standards: HTML5, CSS3, JSON, SVG
-Components: Modernizr, jQuery, ZURB Foundation, Moment.js, Fastclick
-Software: Node.js, Gulp, EditorConfig, TravisCI, Git, Bower, NPM
+Components: jQuery, ZURB Foundation
+Software: Node.js, EditorConfig
 
 Pure logical thinking cannot yield us any knowledge of the empirical world; all knowledge of reality starts from experience and ends in it. —Albert Einstein, "Ideas and Opinions"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5103,6 +5103,11 @@
         }
       }
     },
+    "instafeed.js": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/instafeed.js/-/instafeed.js-1.4.1.tgz",
+      "integrity": "sha1-wp15FFY8EXIrNs2SGpHeJSH5zao="
+    },
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -5443,6 +5448,11 @@
       "requires": {
         "jsbn": "~0.1.0"
       }
+    },
+    "jquery": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.3.1.tgz",
+      "integrity": "sha512-Ubldcmxp5np52/ENotGxlLe6aGMvmF4R8S6tZjsP6Knsaxd/xp3Zrh50cG93lR6nPXyUFwzN3ZSOQI0wRJNdGg=="
     },
     "js-levenshtein": {
       "version": "1.1.6",
@@ -8685,6 +8695,14 @@
             "safe-buffer": "~5.1.0"
           }
         }
+      }
+    },
+    "timeago": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/timeago/-/timeago-1.6.3.tgz",
+      "integrity": "sha512-x97d1X1KsNapWJTgCOOAy/59XagYu2WsDTAH/yvPsWi5bqtGbLPaVZBv3HZ3jTpakHR+JGGyrI9qC0yuvIAvnQ==",
+      "requires": {
+        "jquery": ">=1.2.3"
       }
     },
     "timed-out": {

--- a/package.json
+++ b/package.json
@@ -64,6 +64,8 @@
     }
   ],
   "dependencies": {
-    "@babel/polyfill": "^7.2.5"
+    "@babel/polyfill": "^7.2.5",
+    "instafeed.js": "^1.4.1",
+    "timeago": "^1.6.3"
   }
 }

--- a/vendor-packages.txt
+++ b/vendor-packages.txt
@@ -4,6 +4,5 @@
 ./bower_components/foundation/js/foundation/foundation.dropdown.js
 ./bower_components/foundation/js/foundation/foundation.magellan.js
 ./bower_components/foundation/js/foundation/foundation.orbit.js
-./bower_components/foundation/js/foundation/foundation.tooltip.js
 ./bower_components/foundation/js/foundation/foundation.topbar.js
 ./node_modules/instafeed.js/instafeed.min.js

--- a/vendor-packages.txt
+++ b/vendor-packages.txt
@@ -1,7 +1,4 @@
 ./bower_components/jquery/dist/jquery.js
-./bower_components/modernizr/modernizr.js
-./bower_components/fastclick/lib/fastclick.js
-./bower_components/jquery.cookie/jquery.cookie.js
 ./node_modules/timeago/jquery.timeago.js
 ./bower_components/foundation/js/foundation/foundation.js
 ./bower_components/foundation/js/foundation/foundation.dropdown.js

--- a/vendor-packages.txt
+++ b/vendor-packages.txt
@@ -2,12 +2,11 @@
 ./bower_components/modernizr/modernizr.js
 ./bower_components/fastclick/lib/fastclick.js
 ./bower_components/jquery.cookie/jquery.cookie.js
-./bower_components/jquery-timeago/jquery.timeago.js
-./bower_components/jquery-placeholder/jquery.placeholder.js
+./node_modules/timeago/jquery.timeago.js
 ./bower_components/foundation/js/foundation/foundation.js
 ./bower_components/foundation/js/foundation/foundation.dropdown.js
 ./bower_components/foundation/js/foundation/foundation.magellan.js
 ./bower_components/foundation/js/foundation/foundation.orbit.js
 ./bower_components/foundation/js/foundation/foundation.tooltip.js
 ./bower_components/foundation/js/foundation/foundation.topbar.js
-./bower_components/instafeed.js/instafeed.js
+./node_modules/instafeed.js/instafeed.min.js


### PR DESCRIPTION
This PR refactors all JS dependencies – except Bower and jQuery – to use npm instead of Bower.