### PR TITLE
refactor: navbars to build from new navigation data file

### DIFF
--- a/_data/navigation.json
+++ b/_data/navigation.json
@@ -1,0 +1,40 @@
+{
+  "top": {
+    "left": [{
+      "path": "/#projects",
+      "slug": "projects",
+      "text": "Projects",
+      "title": "Projects"
+    }, {
+      "path": "/#blog",
+      "slug": "blog",
+      "text": "Blog",
+      "title": "Blog Posts"
+    }, {
+      "path": "/#photos",
+      "slug": "photos",
+      "text": "Photos",
+      "title": "Photos"
+    }, {
+      "class": "hidden",
+      "path": "/#recently-read",
+      "slug": "recently-read",
+      "text": "Recently Read",
+      "title": "Recently read books"
+    }],
+    "right": [{
+      "path": "https://stats.chrisvogt.me",
+      "text": "Stats",
+      "title": "Coding stats — last 30 days"
+    }]
+  },
+  "bottom": [{
+    "path": "https://stats.chrisvogt.me",
+    "title": "Chris Vogt's open source stats",
+    "text": "Stats"
+  }, {
+    "path": "https://resume.chrisvogt.me",
+    "title": "Chris Vogt on StackOverflow",
+    "text": "<i class='fab fa-stack-overflow' aria-hidden='true'></i> Developer Story"
+  }]
+}

--- a/_includes/component/blog-posts.html
+++ b/_includes/component/blog-posts.html
@@ -1,4 +1,4 @@
-<section id="blog-posts" data-magellan-destination="blog-posts">
+<section id="blog" data-magellan-destination="blog">
     <div class="row">
       <div class="panel large-12 columns">
 

--- a/_includes/component/top-navigation.html
+++ b/_includes/component/top-navigation.html
@@ -17,35 +17,23 @@
     </ul>
     <section class="top-bar-section" data-magellan-expedition>
       <ul class="left">
-        <li class="link-projects" data-magellan-arrival="projects">
-          <a href="/#projects" title="Projects">
-            Projects
-          </a>
-        </li>
-        {% if site.posts.size > 0 %}
-        <li class="link-blog {% if page.layout == 'post' %}active{% endif %}" data-magellan-arrival="blog-posts">
-          <a href="/#blog-posts" title="Blog Posts">
-            Blog
-          </a>
-        </li>
-        {% endif %}
-        <li data-magellan-arrival="photos">
-          <a href="/#photos" title="Photos">
-            Photos
-          </a>
-        </li>
-        <li class="hidden" data-magellan-arrival="recently-read">
-          <a href="/#recently-read" title="Recently read books">
-            Recently Read
-          </a>
-        </li>
+        {% for item in site.data.navigation.top.left %}
+          {% if item.slug == 'blog' and site.posts.size == 0 %}{% break %}{% endif %}
+          <li class="link-{{ item.slug }}{% if item.class %} {{ item.class }}{% endif %}{% if item.slug == 'blog' and page.layout == 'post' %} active{% endif %}" data-magellan-arrival="{{ item.slug }}">
+            <a href="{{ item.path }}" title="{{ item.title }}">
+              {{ item.text }}
+            </a>
+          </li>
+        {% endfor %}
       </ul>
       <ul class="right">
+        {% for item in site.data.navigation.top.right %}
         <li>
-          <a href="https://stats.chrisvogt.me" title="Coding stats — last 30 days">
-            Stats
+          <a href="{{ item.path }}" title="{{ item.title }}">
+            {{ item.text }}
           </a>
         </li>
+        {% endfor %}
       </ul>
     </section>
   </nav>

--- a/_includes/section/footer.html
+++ b/_includes/section/footer.html
@@ -9,16 +9,13 @@
         {% endif %}
         <div class="small-12 {% if site.theme_options.show_credits %}medium-6 columns{% endif %}">
           <ul class="inline-list">
+            {% for item in site.data.navigation.bottom %}
             <li>
-              <a href="https://stats.chrisvogt.me" title="Chris Vogt's open source stats">
-                Stats
+              <a href="{{ item.path }}" title="{{ item.title }}">
+                {{ item.text }}
               </a>
             </li>
-            <li>
-              <a href="https://resume.chrisvogt.me" title="Chris Vogt on StackOverflow">
-                <i class="fab fa-stack-overflow" aria-hidden="true"></i> Developer Story
-              </a>
-            </li>
+            {% endfor %}
           </ul>
         </div>
       </div>


### PR DESCRIPTION
This closes #99 by refactoring the navigation includes to loop through items defined in a new data file at _\_data/navigation.json_ while also hiding the blog link when no blogs exist and supporting custom classes for some navigation elements.