### PR TITLE
hack: fix Instagram preview image on large resolutions

### DIFF
--- a/assets/styles/components/_photos.scss
+++ b/assets/styles/components/_photos.scss
@@ -101,6 +101,11 @@ body.ig-modal-open {
             position: fixed;
             transform: translate(-50%, -50%);
         }
+
+        // HACK: quick fix for an issue (#109) visible on large resolutions
+        @media only screen and (min-width: 1400px) {
+            max-width: 1280px;
+        }
     }
 
     .relative {


### PR DESCRIPTION
This is a quick bandaid for #109 that caps the maximum width of the modal to prevent the Instagram preview columns from growing beyond the width of the image.

### Screenshots

###### Before

<img width="1885" alt="screenshot-issue" src="https://user-images.githubusercontent.com/1934719/52935904-8925e980-330f-11e9-9f2f-12af96126c01.PNG">

###### After

<img width="1050" alt="screen shot 2019-02-17 at 11 53 01 pm" src="https://user-images.githubusercontent.com/1934719/52935915-9216bb00-330f-11e9-9426-ca3a7222ec0e.png">
