### PR TITLE
fix: missing location name breaks instagram component

### DIFF
--- a/_includes/js/renderers/instagram-modal.js
+++ b/_includes/js/renderers/instagram-modal.js
@@ -22,7 +22,7 @@ export default ({dom, photo}) => {
   content.querySelector('.img-modal-avatar').src = photo.profilePicture;
   content.querySelector('.ig-modal-image').src = photo.images.standard_resolution.url;
   content.querySelector('.ig--modal-link').href = photo.link;
-  content.querySelector('.ig-modal-location').textContent = photo.locationName;
+  content.querySelector('.ig-modal-location').textContent = photo.locationName || '';
   content.querySelector('.ig-modal-text').textContent = photo.text;
   content.querySelector('.ig-time-ago').textContent = getRelativeTimeSinceString(photo.createdAt);
 

--- a/_includes/js/utils/transform-photos.js
+++ b/_includes/js/utils/transform-photos.js
@@ -18,9 +18,6 @@ export default (acc, photo = {}) => {
     } = {},
     type,
     link,
-    location: {
-      name: locationName = ''
-    } = {},
     created_time: createdAt
   } = photo;
 
@@ -32,7 +29,7 @@ export default (acc, photo = {}) => {
     images,
     likesCount,
     link,
-    locationName,
+    locationName: photo.location ? photo.location.name : null,
     profilePicture,
     text,
     type,


### PR DESCRIPTION
This PR resolves #130 by allowing Instagram photos to render when no location name is specified.

### Screenshots

###### Before

<img width="1253" alt="Screenshot – Instagram component fails to load" src="https://user-images.githubusercontent.com/1934719/56550619-f71ea500-653a-11e9-91b2-0089f4c25db4.png">

###### After

<img width="1253" alt="Screenshot – Instagram component loads correctly" src="https://user-images.githubusercontent.com/1934719/56550631-fede4980-653a-11e9-908d-6f64d203fc0c.png">
