### PR TITLE
fix: broken repo placeholder elements

### DIFF
--- a/_includes/template/latest-repos/placeholder.html
+++ b/_includes/template/latest-repos/placeholder.html
@@ -1,7 +1,7 @@
 <template id="latest-repo-placeholder">
-  <div class="latest-repos-link col-xs-12 col-md-6">
-      <div class="latest-repo-item panel hvr-trim">
-        <div class="bg-placeholder">
+  <div class="latest-repos-link col-xs-12 col-md-6 mb-3">
+      <div class="latest-repo-item panel hvr-trim w-100 h-100">
+        <div class="bg-placeholder rounded" style="overflow: hidden;">
           <div class="placeholder-mask header-top"></div>
           <div class="placeholder-mask header-right"></div>
           <div class="placeholder-mask header-bottom"></div>


### PR DESCRIPTION
This PR fixes the broken placeholder elements.

### Screenshots

###### Before

![screenshot-before](https://user-images.githubusercontent.com/1934719/57597833-cf04df00-7505-11e9-9952-636adc5008db.gif)

###### After

![screenshot-after](https://user-images.githubusercontent.com/1934719/57597842-d75d1a00-7505-11e9-8f6e-d7fad006a8e1.gif)
