### PR TITLE
refactor: switch default latest repos endpoint

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -13,7 +13,7 @@ destination: _site
 
 components:
   instagram: https://api.chrisvogt.me/instagram
-  latest_repos: https://gh-latest-repos-fmyaneprcd.now.sh
+  latest_repos: https://metrics.chrisvogt.me/api/latest-repositories
   latest_commit:
     url: https://api.github.com/users/{username}/events/public
     username: chrisvogt

--- a/_includes/js/latest-repos.js
+++ b/_includes/js/latest-repos.js
@@ -24,7 +24,7 @@ export default async ({config, dom, jQuery}) => {
   try {
     const {getJSON} = jQuery;
     const response = await getJSON({url});
-    const repos = response.reverse().filter(repo => Boolean(repo.description));
+    const repos = response.reverse().slice(0, 7).filter(repo => Boolean(repo.description));
 
     container.innerHTML = '';
 

--- a/_includes/js/recently-read.js
+++ b/_includes/js/recently-read.js
@@ -13,7 +13,6 @@ export default async ({config, dom, jQuery}) => {
 
   const bookList = dom.select('#recent-books');
   const container = dom.select('#recently-read');
-  // const navButton = dom.select('#primary-nav li');
   const template = dom.select('#recent-book-template').content;
 
   try {

--- a/_includes/section/header.html
+++ b/_includes/section/header.html
@@ -63,7 +63,6 @@
           "https://twitter.com/c1v0",
           "https://www.instagram.com/c1v0",
           "https://www.linkedin.com/in/cjvogt",
-          "https://plus.google.com/+chrisvogt94952",
           "https://github.com/chrisvogt",
           "https://www.behance.net/chrisvogt",
           "https://stackoverflow.com/users/1391826/chris-vogt",
@@ -73,12 +72,11 @@
     </script>
     {% endif %}
 
-    <link rel="dns-prefetch" href="//api.github.com">
-    <link rel="dns-prefetch" href="//apis.google.com">
-    <link rel="dns-prefetch" href="//books.google.com">
-    <link rel="dns-prefetch" href="//chrisvogt.firebaseio.com">
-    <link rel="dns-prefetch" href="//pro.fontawesome.com">
+    <link rel="dns-prefetch" href="//api.chrisvogt.me">
+    <link rel="dns-prefetch" href="//metrics.chrisvogt.me">
     <link rel="dns-prefetch" href="//recently-read.chrisvogt.me">
+    <link rel="dns-prefetch" href="//api.github.com">
+    <link rel="dns-prefetch" href="//pro.fontawesome.com">
     <link rel="dns-prefetch" href="//scontent.cdninstagram.com">
   </head>
   <body class="page-{{ layout.slug }}">


### PR DESCRIPTION
This PR updates the default latest repositories endpoint to be a new Firebase function I have deployed. It also caps the repositories rendered at 6 items.