### PR TITLE
chore: ignore bundler user install dependencies

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,0 +1,2 @@
+---
+BUNDLE_PATH: "vendor/bundle"

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ _site
 assets/js/*.js
 node_modules
 npm-debug.log
+vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-  - v8
+  - v10
 before_install:
   - cp _config.yml _config.prod.yml
   - gem install bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ node_js:
 before_install:
   - cp _config.yml _config.prod.yml
   - gem install bundler
-  - bundle install
+  - bundle install --path vendor/bundle
   - npm install
 install:
   - npm run build

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Many of the available UI components depend on external data. This table document
 
 | Tool    | Version | Link                      | Description                      |
 |---------|---------|---------------------------|----------------------------------|
-| Node    | 8       | https://nodejs.org        | Dev & build environment language |
+| Node    | 10       | https://nodejs.org        | Dev & build environment language |
 | npm     | 6       | https://npmjs.com         | JavaScript dependency management |
 | Ruby    | 2       | https://www.ruby-lang.org | Dev & build environment language |
 | Bundler | >1.14   | https://bundler.io        | Ruby dependency management       |

--- a/_config.yml
+++ b/_config.yml
@@ -58,4 +58,5 @@ exclude:
   - node_modules
   - package-lock.json
   - package.json
+  - vendor
   - vendor-packages.txt

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@personal-site/blog",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@personal-site/blog",
-  "description": "Jekyll blog with GitHub, Instagram, and social widgets.",
-  "version": "0.10.0",
+  "description": "Jekyll blog with GitHub, Instagram, and Goodreads widgets.",
+  "version": "0.11.0",
   "homepage": "https://www.chrisvogt.me",
   "author": {
     "name": "Chris Vogt",
@@ -23,7 +23,7 @@
     "js:clean": "rm ./assets/js/*.js",
     "js:min": "minify ./assets/js/app.js -d ./assets/js",
     "js:vendors": "uglifyjs $(cat ./vendor-packages.txt) -o ./assets/js/vendor.min.js",
-    "build": "npm run js:vendors && npm run js:babel && npm run js:min && jekyll build --config _config.prod.yml",
+    "build": "npm run js:vendors && npm run js:babel && npm run js:min && bundle exec jekyll build --config _config.prod.yml",
     "prestart": "npm run js:vendors",
     "start": "npm run js & bundle exec jekyll serve --watch --incremental --drafts",
     "pretest": "npm run build",


### PR DESCRIPTION
Bundler dependencies installed without elevated privileges end up in a directory called `vendor`. 